### PR TITLE
Docker環境とMakefileの追加

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,10 @@
 LOG_LEVEL=debug
 
-SERVER_URL=http://localhost
+# ========================================
+# Docker環境用の設定（デフォルト）
+# ========================================
+# コンテナ内でサーバーが全てのインターフェースでリッスン
+SERVER_URL=http://0.0.0.0
 SERVER_PORT=8080
 
 # PostgreSQL設定
@@ -10,5 +14,13 @@ POSTGRES_DB=fridgers
 POSTGRES_PORT=5432
 
 # アプリケーションからのDB接続設定
-DB_URL=localhost
+# Docker Composeではサービス名で接続
+DB_URL=postgres
 DB_PORT=5432
+
+# ========================================
+# ローカル開発用の設定（Dockerなし）
+# ========================================
+# cargo run --bin rest-server で起動する場合は以下に変更:
+# SERVER_URL=http://localhost
+# DB_URL=localhost

--- a/.env.template
+++ b/.env.template
@@ -3,5 +3,12 @@ LOG_LEVEL=debug
 SERVER_URL=http://localhost
 SERVER_PORT=8080
 
+# PostgreSQL設定
+POSTGRES_USER=fridgers
+POSTGRES_PASSWORD=fridgers_password
+POSTGRES_DB=fridgers
+POSTGRES_PORT=5432
+
+# アプリケーションからのDB接続設定
 DB_URL=localhost
-DB_PORT=50051
+DB_PORT=5432

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+.PHONY: help up down restart build logs clean dev test check fmt clippy db-shell db-reset
+
+# デフォルトターゲット
+.DEFAULT_GOAL := help
+
+# 色付き出力用
+BLUE := \033[36m
+RESET := \033[0m
+
+help: ## ヘルプを表示
+	@echo "$(BLUE)利用可能なコマンド:$(RESET)"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(RESET) %s\n", $$1, $$2}'
+
+# ========================================
+# Docker Compose コマンド
+# ========================================
+
+up: ## Docker Composeでコンテナを起動
+	cd deployments/api && docker-compose up -d
+	@echo "$(BLUE)コンテナが起動しました$(RESET)"
+	@echo "API: http://localhost:8080"
+	@echo "PostgreSQL: localhost:5432"
+
+down: ## コンテナを停止
+	cd deployments/api && docker-compose down
+	@echo "$(BLUE)コンテナを停止しました$(RESET)"
+
+restart: down up ## コンテナを再起動
+
+build: ## Dockerイメージをビルド
+	cd deployments/api && docker-compose build
+	@echo "$(BLUE)イメージのビルドが完了しました$(RESET)"
+
+logs: ## コンテナのログを表示
+	cd deployments/api && docker-compose logs -f
+
+clean: ## コンテナとボリュームを削除
+	cd deployments/api && docker-compose down -v
+	@echo "$(BLUE)コンテナとボリュームを削除しました$(RESET)"
+
+# ========================================
+# データベースコマンド
+# ========================================
+
+db-shell: ## PostgreSQLに接続
+	docker exec -it fridgers-backend-postgres psql -U fridgers -d fridgers
+
+db-reset: ## データベースをリセット
+	cd deployments/api && docker-compose down -v
+	cd deployments/api && docker-compose up -d postgres
+	@echo "$(BLUE)データベースをリセットしました$(RESET)"
+
+# ========================================
+# ローカル開発コマンド
+# ========================================
+
+dev: ## ローカルでRustサーバーを起動
+	cargo run --bin rest-server
+
+test: ## テストを実行
+	cargo test
+
+check: ## コードをチェック（ビルドなし）
+	cargo check
+
+fmt: ## コードをフォーマット
+	cargo fmt
+
+clippy: ## Clippyリンターを実行
+	cargo clippy
+
+# ========================================
+# 便利なエイリアス
+# ========================================
+
+start: up ## upのエイリアス
+
+stop: down ## downのエイリアス
+
+psql: db-shell ## db-shellのエイリアス

--- a/deployments/api/.dockerignore
+++ b/deployments/api/.dockerignore
@@ -1,0 +1,32 @@
+# Git関連
+.git
+.gitignore
+
+# IDE/エディタ
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Rust
+target/
+**/*.rs.bk
+Cargo.lock
+
+# 環境変数
+.env
+.env.*
+!.env.template
+
+# ドキュメント
+*.md
+!CLAUDE.md
+docs/
+
+# CI/CD
+.github/
+
+# その他
+deployments/
+*.log

--- a/deployments/api/Dockerfile
+++ b/deployments/api/Dockerfile
@@ -1,0 +1,49 @@
+# ========================================
+# ビルドステージ
+# ========================================
+FROM rust:1.92.0-bookworm AS builder
+
+WORKDIR /app
+
+# 依存関係のキャッシュを最適化するため、まずCargo.tomlファイルをコピー
+COPY Cargo.toml ./
+COPY rust-toolchain.toml ./
+COPY src ./src
+
+# リリースビルドを実行
+RUN cargo build --release --bin rest-server
+
+# ========================================
+# ランタイムステージ
+# ========================================
+FROM debian:bookworm-slim
+
+# 必要なランタイム依存関係をインストール
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# 非rootユーザーを作成
+RUN useradd -m -u 1000 appuser
+
+WORKDIR /app
+
+# ビルドステージからバイナリをコピー
+COPY --from=builder /app/target/release/rest-server /app/rest-server
+
+# アプリケーションの所有権を変更
+RUN chown -R appuser:appuser /app
+
+# 非rootユーザーに切り替え
+USER appuser
+
+# ポートを公開
+EXPOSE 8080
+
+# ヘルスチェック
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/bin/sh", "-c", "test -f /app/rest-server"]
+
+# アプリケーションを起動
+CMD ["/app/rest-server"]

--- a/deployments/api/docker-compose.yml
+++ b/deployments/api/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: fridgers-backend-postgres
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-fridgers}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-fridgers_password}
+      - POSTGRES_DB=${POSTGRES_DB:-fridgers}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-fridgers}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - fridgers-network
+
+  api:
+    build:
+      context: ../../
+      dockerfile: deployments/api/Dockerfile
+    container_name: fridgers-backend-api
+    ports:
+      - "8080:8080"
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - SERVER_URL=${SERVER_URL:-http://0.0.0.0}
+      - SERVER_PORT=${SERVER_PORT:-8080}
+      - DB_URL=${DB_URL:-postgres}
+      - DB_PORT=${DB_PORT:-5432}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-fridgers}:${POSTGRES_PASSWORD:-fridgers_password}@postgres:5432/${POSTGRES_DB:-fridgers}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - fridgers-network
+
+volumes:
+  postgres_data:
+    driver: local
+
+networks:
+  fridgers-network:
+    driver: bridge


### PR DESCRIPTION
## 概要
ローカル開発環境用のDocker環境を構築し、Makefileによるコマンド簡素化を実装しました。

## 主な変更内容

### 1. Docker環境の構築
**Dockerfile** (`deployments/api/Dockerfile`)
- マルチステージビルドでRust APIをコンテナ化
- ビルドステージ: `rust:1.92.0-bookworm`
- ランタイムステージ: `debian:bookworm-slim`（軽量化）
- 非rootユーザー（appuser）で実行してセキュリティを確保
- ポート8080を公開

**Docker Compose** (`deployments/api/docker-compose.yml`)
- PostgreSQL 16（Alpine版）コンテナを追加
- データ永続化用のvolume設定
- ヘルスチェックによる依存関係管理（API起動前にDBが準備完了）
- ネットワーク分離（fridgers-network）

**.dockerignore** (`deployments/api/.dockerignore`)
- ビルドコンテキストの最適化
- 不要なファイルを除外してビルド時間を短縮

### 2. Makefileの追加
プロジェクトルートにMakefileを作成し、開発コマンドを簡素化：

**Docker環境操作**
- `make up`: コンテナ起動
- `make down`: コンテナ停止
- `make logs`: ログ表示
- `make build`: イメージビルド
- `make clean`: コンテナとボリューム削除

**データベース操作**
- `make db-shell` / `make psql`: PostgreSQLに接続
- `make db-reset`: データベースリセット

**Rust開発**
- `make dev`: ローカルでサーバー起動
- `make test`: テスト実行
- `make check`: コードチェック
- `make fmt`: フォーマット
- `make clippy`: リンター実行

### 3. 環境変数の整備
**.env.template**の更新
- PostgreSQL接続設定を追加（POSTGRES_USER/PASSWORD/DB/PORT）
- Docker環境用の設定をデフォルトに
  - `SERVER_URL=http://0.0.0.0`: コンテナ内で全インターフェースでリッスン
  - `DB_URL=postgres`: Docker Composeのサービス名で接続
- ローカル開発用の設定をコメントで説明

## 使い方

```bash
# 環境変数ファイルを準備（初回のみ）
cp .env.template .env

# Docker環境を起動
make up

# ログを確認
make logs

# PostgreSQLに接続
make psql

# コンテナを停止
make down
```

## 技術的な詳細

### Docker Compose環境での接続
- **APIコンテナ → PostgreSQLコンテナ**: `postgres:5432`（サービス名）
- **ホストマシン → APIコンテナ**: `localhost:8080`（ポートマッピング）
- **ホストマシン → PostgreSQLコンテナ**: `localhost:5432`（ポートマッピング）

### セキュリティ考慮事項
- 非rootユーザーでの実行
- .envファイルは.gitignoreで除外（機密情報保護）
- ヘルスチェックによる安全な起動順序制御

## 今後の展開
- 本番環境用のDocker設定（GCP Cloud Run想定）
- マルチアーキテクチャビルド対応（ARM64/x86_64）
- データベースマイグレーション自動化

🤖 Generated with [Claude Code](https://claude.com/claude-code)