### PR TITLE
fix: define_string! の長さ判定をバイト数から文字数に修正 (#16)

### DIFF
--- a/src/domain/src/string.rs
+++ b/src/domain/src/string.rs
@@ -62,13 +62,14 @@ macro_rules! define_string {
             type Error = $crate::error::Error;
 
             fn try_from(value: String) -> $crate::error::Result<Self> {
-                if value.len() < $min {
+                let char_count = value.chars().count();
+                if char_count < $min {
                     return Err($crate::error::Error::InvalidLengthRange(format!(
                         concat!(stringify!($t), " must be at least {} characters"),
                         $min,
                     )));
                 }
-                if value.len() > $max {
+                if char_count > $max {
                     return Err($crate::error::Error::InvalidLengthRange(format!(
                         concat!(stringify!($t), " cannot exceed {} characters"),
                         $max,

--- a/src/domain/src/user/raw_password.rs
+++ b/src/domain/src/user/raw_password.rs
@@ -1,3 +1,35 @@
 use crate::string::define_string;
 
 define_string!(RawPassword, min = 10, max = 30);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn ten_chars_is_ok() {
+        assert!(RawPassword::try_from("a".repeat(10)).is_ok());
+    }
+
+    #[test]
+    fn nine_chars_is_err() {
+        assert!(matches!(
+            RawPassword::try_from("a".repeat(9)),
+            Err(Error::InvalidLengthRange(_))
+        ));
+    }
+
+    #[test]
+    fn multibyte_min_counted_by_chars_not_bytes() {
+        // 10文字のマルチバイトは min=10 を満たす（= 30 バイト）
+        // バイト数判定だと「30 バイト >= 10 バイト」で偶然 OK になるが、
+        // バイト判定だと逆に「3文字 = 9バイト < 10」で 3文字でも弾けてしまう。
+        // 文字数判定なら「3文字 < 10」で確実に弾ける。
+        assert!(RawPassword::try_from("あ".repeat(10)).is_ok());
+        assert!(matches!(
+            RawPassword::try_from("あ".repeat(9)),
+            Err(Error::InvalidLengthRange(_))
+        ));
+    }
+}

--- a/src/domain/src/user/user_name.rs
+++ b/src/domain/src/user/user_name.rs
@@ -1,3 +1,60 @@
 use crate::string::define_string;
 
 define_string!(UserName, max = 25);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn ascii_within_max_is_ok() {
+        // 25文字のASCII（境界値）
+        let name = "a".repeat(25);
+        assert!(UserName::try_from(name).is_ok());
+    }
+
+    #[test]
+    fn ascii_over_max_is_err() {
+        let name = "a".repeat(26);
+        assert!(matches!(
+            UserName::try_from(name),
+            Err(Error::InvalidLengthRange(_))
+        ));
+    }
+
+    #[test]
+    fn multibyte_counted_by_chars_not_bytes() {
+        // 11文字 = UTF-8 で 33 バイト。25バイト判定だと弾かれてしまうがOKであるべき
+        let name = "ケースインセンシティブ".to_string();
+        assert_eq!(name.chars().count(), 11);
+        assert_eq!(name.len(), 33);
+        assert!(UserName::try_from(name).is_ok());
+    }
+
+    #[test]
+    fn multibyte_at_max_boundary_is_ok() {
+        // 25文字（マルチバイト）= 75バイト
+        let name = "あ".repeat(25);
+        assert_eq!(name.chars().count(), 25);
+        assert!(UserName::try_from(name).is_ok());
+    }
+
+    #[test]
+    fn multibyte_over_max_is_err() {
+        let name = "あ".repeat(26);
+        assert!(matches!(
+            UserName::try_from(name),
+            Err(Error::InvalidLengthRange(_))
+        ));
+    }
+
+    #[test]
+    fn empty_is_err() {
+        // min=1（define_string! の `max = ...` バリエーションは min=1 にデフォルト）
+        assert!(matches!(
+            UserName::try_from(String::new()),
+            Err(Error::InvalidLengthRange(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- \`define_string!\` マクロが \`value.len()\`（バイト長）で min/max 判定していたため、UTF-8 マルチバイト文字（日本語など）が想定より早く弾かれていた
- \`value.chars().count()\` に置き換え、文字数で判定するよう修正
- \`UserName\` (max=25) / \`RawPassword\` (min=10, max=30) でマルチバイト境界値テストを追加

Closes #16

## 影響を受ける値オブジェクト

\`define_string!\` を使うすべての型: \`UserName\` / \`FridgeName\` / \`CompartmentName\` / \`ItemName\` / \`ItemUnit\` / \`RawPassword\` 等

## 動作変化

| ケース | 修正前 | 修正後 |
|---|---|---|
| UserName に「ケースインセンシティブ」(11文字, 33バイト) | 400 (バイト数 > 25) | 201 |
| UserName に「a」×25 | 201 | 201 |
| UserName に「あ」×25 | 400 (75バイト > 25) | 201 |
| RawPassword に「あ」×3 (3文字, 9バイト) | 「9バイト < 10」で 400（偶然OK） | 「3文字 < 10」で 400（意図通り） |

セキュリティ面での後退はなし。むしろ \`RawPassword\` の min 判定が文字数ベースになるため、マルチバイト混在で「3文字パスワード」が通る抜け道が無くなる。

## Test plan
- [x] \`cargo test -p fridgers-backend-domain\` (14/14 pass)
- [x] \`cargo test --test integration_test -- --test-threads=1\` (13/13 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)