### PR TITLE
feat!: 全エンドポイントに JWT 認可を導入 (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,10 @@ make api-down
   - Claims: `sub`（UserID）、`exp`（有効期限）、`iat`（発行日時）
   - 設定: `JwtConfig { secret, expiry_hours }`（環境変数`AUTH_*`から読み込み）
 - **フロー**: ユーザー登録（POST /v1/users） → ログイン（POST /v1/auth/login） → JWTトークン取得
-- **認可ミドルウェア**: 未実装（今後の課題）
+- **認可**: `POST /v1/users` と `POST /v1/auth/login` 以外のすべてのエンドポイントで Bearer 必須
+  - Actix の `FromRequest` を実装した `AuthenticatedUser` 抽出器（`src/interface/rest-controller/src/extractor/authenticated_user.rs`）でハンドラの引数として透過的に取得
+  - 各 Interactor メソッドは `requesting_user_id: &str` を受け取り、`verify_fridge_ownership` / `verify_compartment_ownership` でリソースのオーナーが一致することを確認
+  - 他人のリソースへのアクセスはリソース存在の漏洩を防ぐため `404 Not Found` を返す（`403 Forbidden` ではなく）
 
 ### Docker構成
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -603,17 +603,12 @@ components:
       type: object
       required:
         - name
-        - owner_user_id
       properties:
         name:
           type: string
           minLength: 1
           maxLength: 50
           description: 冷蔵庫名（英数字・スペース・ハイフン・アンダースコア）
-        owner_user_id:
-          type: string
-          format: uuid
-          description: オーナーユーザーID
 
     CreateFridgeResponse:
       type: object

--- a/src/apps/rest-server/src/bin.rs
+++ b/src/apps/rest-server/src/bin.rs
@@ -13,13 +13,14 @@ async fn main() -> std::io::Result<()> {
     setup::setup_logger(&config)?;
 
     // 依存性の構築
-    let interactor = setup::setup_dependencies(&config).await?;
+    let (interactor, jwt_config) = setup::setup_dependencies(&config).await?;
 
     // HTTPサーバーの起動
     HttpServer::new(move || {
         App::new()
             // DIコンテナの登録
             .app_data(web::Data::new(interactor.clone()))
+            .app_data(web::Data::new(jwt_config.clone()))
             // トレース用のスパンを追加
             .wrap_fn(|req, srv| {
                 let span = info_span!(

--- a/src/apps/rest-server/src/setup.rs
+++ b/src/apps/rest-server/src/setup.rs
@@ -23,7 +23,7 @@ pub fn setup_logger(config: &Config) -> std::io::Result<()> {
 /// 依存性の構築（DI Container）
 pub async fn setup_dependencies(
     config: &Config,
-) -> std::io::Result<Arc<Interactor<PostgresRepository>>> {
+) -> std::io::Result<(Arc<Interactor<PostgresRepository>>, JwtConfig)> {
     let pool = PgPool::connect(&config.db.database_url)
         .await
         .map_err(|e| {
@@ -39,5 +39,6 @@ pub async fn setup_dependencies(
     };
 
     let repository = PostgresRepository::new(pool);
-    Ok(Arc::new(Interactor::new(repository, jwt_config)))
+    let interactor = Arc::new(Interactor::new(repository, jwt_config.clone()));
+    Ok((interactor, jwt_config))
 }

--- a/src/apps/rest-server/tests/fridge/mod.rs
+++ b/src/apps/rest-server/tests/fridge/mod.rs
@@ -40,8 +40,8 @@ where
     (user_id, token)
 }
 
-/// 指定ユーザーが所有する冷蔵庫を作成する
-async fn create_fridge<S>(app: &S, owner_user_id: &str, name: &str) -> String
+/// 認証済ユーザー（token のオーナー）として冷蔵庫を作成する
+async fn create_fridge<S>(app: &S, token: &str, name: &str) -> String
 where
     S: actix_web::dev::Service<
             actix_http::Request,
@@ -51,10 +51,8 @@ where
 {
     let req = test::TestRequest::post()
         .uri("/v1/fridges")
-        .set_json(json!({
-            "name": name,
-            "owner_user_id": owner_user_id,
-        }))
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .set_json(json!({ "name": name }))
         .to_request();
     let resp = test::call_service(app, req).await;
     assert_eq!(resp.status().as_u16(), 201);
@@ -69,8 +67,8 @@ async fn test_list_fridges_success_returns_owned_fridges() {
     let (user_id, token) =
         register_and_login(&app, "オーナーA", "owner-a@example.com", "password123").await;
 
-    let id1 = create_fridge(&app, &user_id, "主冷蔵庫").await;
-    let id2 = create_fridge(&app, &user_id, "サブ冷蔵庫").await;
+    let id1 = create_fridge(&app, &token, "主冷蔵庫").await;
+    let id2 = create_fridge(&app, &token, "サブ冷蔵庫").await;
 
     let req = test::TestRequest::get()
         .uri("/v1/fridges")
@@ -119,15 +117,15 @@ async fn test_list_fridges_isolates_other_users_fridges() {
     let (app, pool) = helper::create_test_app().await;
 
     // ユーザーA: 冷蔵庫を2件持つ
-    let (user_a_id, _token_a) =
+    let (_user_a_id, token_a) =
         register_and_login(&app, "ユーザーA", "user-a@example.com", "password123").await;
-    create_fridge(&app, &user_a_id, "Aの冷蔵庫1").await;
-    create_fridge(&app, &user_a_id, "Aの冷蔵庫2").await;
+    create_fridge(&app, &token_a, "Aの冷蔵庫1").await;
+    create_fridge(&app, &token_a, "Aの冷蔵庫2").await;
 
     // ユーザーB: 冷蔵庫を1件持つ
     let (user_b_id, token_b) =
         register_and_login(&app, "ユーザーB", "user-b@example.com", "password123").await;
-    let b_fridge_id = create_fridge(&app, &user_b_id, "Bの冷蔵庫").await;
+    let b_fridge_id = create_fridge(&app, &token_b, "Bの冷蔵庫").await;
 
     // BがGETすると自分の1件だけが返る
     let req = test::TestRequest::get()
@@ -205,6 +203,176 @@ async fn test_list_fridges_accepts_lowercase_bearer_scheme() {
     let resp = test::call_service(&app, req).await;
     // RFC 7235 ではスキーム名は大文字小文字を区別しないため、200を期待
     assert_eq!(resp.status().as_u16(), 200);
+
+    helper::cleanup_users(&pool).await;
+}
+
+// ==== 認可テスト ====
+
+#[actix_rt::test]
+async fn test_create_fridge_without_auth_returns_401() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let req = test::TestRequest::post()
+        .uri("/v1/fridges")
+        .set_json(json!({ "name": "noauth" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 401);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_create_fridge_uses_jwt_user_as_owner() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (user_id, token) =
+        register_and_login(&app, "JWTオーナー", "jwt-owner@example.com", "password123").await;
+
+    // body に owner_user_id を含めず作成
+    let req = test::TestRequest::post()
+        .uri("/v1/fridges")
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .set_json(json!({ "name": "JWT冷蔵庫" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["owner_user_id"], user_id);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_get_fridge_of_other_user_returns_404() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (_user_a_id, token_a) =
+        register_and_login(&app, "owner", "get-owner@example.com", "password123").await;
+    let a_fridge_id = create_fridge(&app, &token_a, "Aの冷蔵庫").await;
+
+    let (_user_b_id, token_b) =
+        register_and_login(&app, "stranger", "get-stranger@example.com", "password123").await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/v1/fridges/{}", a_fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token_b)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    // 他人の冷蔵庫は存在を漏らさず NotFound
+    assert_eq!(resp.status().as_u16(), 404);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_get_fridge_owner_succeeds() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (_user_id, token) =
+        register_and_login(&app, "owner", "get-self@example.com", "password123").await;
+    let fridge_id = create_fridge(&app, &token, "自分の冷蔵庫").await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/v1/fridges/{}", fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 200);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_delete_fridge_of_other_user_returns_404_and_does_not_delete() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (_user_a_id, token_a) =
+        register_and_login(&app, "owner", "del-owner@example.com", "password123").await;
+    let a_fridge_id = create_fridge(&app, &token_a, "Aの冷蔵庫").await;
+
+    let (_user_b_id, token_b) =
+        register_and_login(&app, "stranger", "del-stranger@example.com", "password123").await;
+
+    // B が A の冷蔵庫を消そうとする → 404
+    let req = test::TestRequest::delete()
+        .uri(&format!("/v1/fridges/{}", a_fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token_b)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 404);
+
+    // A 自身が GET したら依然存在することを確認
+    let req = test::TestRequest::get()
+        .uri(&format!("/v1/fridges/{}", a_fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token_a)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 200);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_create_compartment_in_other_user_fridge_returns_404() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (_user_a_id, token_a) =
+        register_and_login(&app, "owner", "comp-owner@example.com", "password123").await;
+    let a_fridge_id = create_fridge(&app, &token_a, "Aの冷蔵庫").await;
+
+    let (_user_b_id, token_b) =
+        register_and_login(&app, "stranger", "comp-stranger@example.com", "password123").await;
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/v1/fridges/{}/compartments", a_fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token_b)))
+        .set_json(json!({ "name": "侵入" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 404);
+
+    helper::cleanup_users(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_create_item_in_other_user_compartment_returns_404() {
+    let (app, pool) = helper::create_test_app().await;
+
+    let (_user_a_id, token_a) =
+        register_and_login(&app, "owner", "item-owner@example.com", "password123").await;
+    let a_fridge_id = create_fridge(&app, &token_a, "Aの冷蔵庫").await;
+
+    // A 自身でコンパートメント作成
+    let req = test::TestRequest::post()
+        .uri(&format!("/v1/fridges/{}/compartments", a_fridge_id))
+        .insert_header(("Authorization", format!("Bearer {}", token_a)))
+        .set_json(json!({ "name": "野菜室" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = test::read_body_json(resp).await;
+    let compartment_id = body["id"].as_str().unwrap().to_string();
+
+    let (_user_b_id, token_b) =
+        register_and_login(&app, "stranger", "item-stranger@example.com", "password123").await;
+
+    let req = test::TestRequest::post()
+        .uri(&format!(
+            "/v1/fridges/{}/compartments/{}/items",
+            a_fridge_id, compartment_id
+        ))
+        .insert_header(("Authorization", format!("Bearer {}", token_b)))
+        .set_json(json!({
+            "name": "侵入物",
+            "quantity": 1.0,
+            "unit": "個",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 404);
 
     helper::cleanup_users(&pool).await;
 }

--- a/src/apps/rest-server/tests/helper/mod.rs
+++ b/src/apps/rest-server/tests/helper/mod.rs
@@ -32,11 +32,12 @@ pub async fn create_test_app() -> (
         secret: "test-secret-key".to_string(),
         expiry_hours: 24,
     };
-    let interactor = Arc::new(Interactor::new(repository, jwt_config));
+    let interactor = Arc::new(Interactor::new(repository, jwt_config.clone()));
 
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(interactor))
+            .app_data(web::Data::new(jwt_config))
             .configure(app::configure_routes::<PostgresRepository>),
     )
     .await;

--- a/src/interface/rest-controller/src/extractor/authenticated_user.rs
+++ b/src/interface/rest-controller/src/extractor/authenticated_user.rs
@@ -1,0 +1,32 @@
+use crate::extractor::extract_bearer_token;
+use actix_web::{FromRequest, HttpRequest, dev::Payload, web};
+use fridgers_backend_use_case::auth::{JwtConfig, decode_token};
+use std::future::{Ready, ready};
+
+/// 認証済ユーザー。Authorization ヘッダの JWT を復号して取得する。
+///
+/// ハンドラの引数として宣言すれば Actix が自動で抽出する。
+/// 抽出に失敗した場合は 401 を返す。
+pub struct AuthenticatedUser {
+    pub user_id: String,
+}
+
+impl FromRequest for AuthenticatedUser {
+    type Error = crate::error::Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        ready(authenticate(req))
+    }
+}
+
+fn authenticate(req: &HttpRequest) -> Result<AuthenticatedUser, crate::error::Error> {
+    let token = extract_bearer_token(req)?;
+    let jwt_config = req
+        .app_data::<web::Data<JwtConfig>>()
+        .expect("JwtConfig must be registered in app_data");
+    let claims = decode_token(token, jwt_config.get_ref())?;
+    Ok(AuthenticatedUser {
+        user_id: claims.sub,
+    })
+}

--- a/src/interface/rest-controller/src/extractor/mod.rs
+++ b/src/interface/rest-controller/src/extractor/mod.rs
@@ -1,3 +1,5 @@
+pub mod authenticated_user;
 pub mod bearer;
 
+pub use authenticated_user::AuthenticatedUser;
 pub use bearer::extract_bearer_token;

--- a/src/interface/rest-controller/src/handler/compartment.rs
+++ b/src/interface/rest-controller/src/handler/compartment.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::extractor::AuthenticatedUser;
 use crate::schema::compartment::create::{self as create_schema};
 use crate::schema::compartment::update::{self as update_schema};
 use actix_web::{HttpResponse, web};
@@ -13,6 +14,7 @@ use uuid::Uuid;
 
 pub async fn create_compartment<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<String>,
     req: web::Json<create_schema::CreateCompartmentRequest>,
 ) -> Result<HttpResponse> {
@@ -26,7 +28,7 @@ pub async fn create_compartment<R: Repository + 'static>(
 
     let use_case_request = CreateCompartmentRequest::new(compartment_id, fridge_id, name);
     let compartment = interactor
-        .handle_create_compartment(use_case_request)
+        .handle_create_compartment(&user.user_id, use_case_request)
         .await?;
 
     let response = create_schema::CreateCompartmentResponse::from(compartment);
@@ -35,6 +37,7 @@ pub async fn create_compartment<R: Repository + 'static>(
 
 pub async fn update_compartment<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<(String, String)>,
     req: web::Json<update_schema::UpdateCompartmentRequest>,
 ) -> Result<HttpResponse> {
@@ -52,7 +55,7 @@ pub async fn update_compartment<R: Repository + 'static>(
 
     let use_case_request = UpdateCompartmentRequest::new(compartment_id, fridge_id, name);
     let compartment = interactor
-        .handle_update_compartment(use_case_request)
+        .handle_update_compartment(&user.user_id, use_case_request)
         .await?;
 
     let response = update_schema::UpdateCompartmentResponse::from(compartment);
@@ -61,11 +64,12 @@ pub async fn update_compartment<R: Repository + 'static>(
 
 pub async fn delete_compartment<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse> {
     let (fridge_id_str, compartment_id_str) = path.into_inner();
     interactor
-        .handle_delete_compartment(&fridge_id_str, &compartment_id_str)
+        .handle_delete_compartment(&user.user_id, &fridge_id_str, &compartment_id_str)
         .await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/src/interface/rest-controller/src/handler/fridge.rs
+++ b/src/interface/rest-controller/src/handler/fridge.rs
@@ -1,9 +1,9 @@
 use crate::error::Result;
-use crate::extractor::extract_bearer_token;
+use crate::extractor::AuthenticatedUser;
 use crate::schema::fridge::create::{self as create_schema};
 use crate::schema::fridge::get::{self as get_schema};
 use crate::schema::fridge::list::{self as list_schema};
-use actix_web::{HttpRequest, HttpResponse, web};
+use actix_web::{HttpResponse, web};
 use fridgers_backend_domain::fridge::{FridgeId, FridgeName};
 use fridgers_backend_domain::user::UserId;
 use fridgers_backend_use_case::{
@@ -13,12 +13,12 @@ use std::sync::Arc;
 
 pub async fn create_fridge<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     req: web::Json<create_schema::CreateFridgeRequest>,
 ) -> Result<HttpResponse> {
     let fridge_id = FridgeId::new();
     let fridge_name = FridgeName::try_from(req.name.clone()).map_err(use_case::Error::from)?;
-    let owner_user_id =
-        UserId::try_from(req.owner_user_id.clone()).map_err(use_case::Error::from)?;
+    let owner_user_id = UserId::try_from(user.user_id).map_err(use_case::Error::from)?;
 
     let use_case_request = dto::CreateFridgeRequest::new(fridge_id, fridge_name, owner_user_id);
 
@@ -30,30 +30,33 @@ pub async fn create_fridge<R: Repository + 'static>(
 
 pub async fn get_fridge<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     let fridge_id = path.into_inner();
-    let fridge_with_compartments = interactor.handle_get_fridge(&fridge_id).await?;
+    let fridge_with_compartments = interactor
+        .handle_get_fridge(&user.user_id, &fridge_id)
+        .await?;
     let response = get_schema::GetFridgeResponse::from(fridge_with_compartments);
     Ok(HttpResponse::Ok().json(response))
 }
 
 pub async fn delete_fridge<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     let fridge_id = path.into_inner();
-    interactor.handle_delete_fridge(&fridge_id).await?;
+    interactor
+        .handle_delete_fridge(&user.user_id, &fridge_id)
+        .await?;
     Ok(HttpResponse::NoContent().finish())
 }
 
 pub async fn list_fridges<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
-    req: HttpRequest,
+    user: AuthenticatedUser,
 ) -> Result<HttpResponse> {
-    let token = extract_bearer_token(&req)?;
-    let claims = use_case::auth::decode_token(token, &interactor.jwt_config)?;
-
-    let response = interactor.handle_list_fridges(&claims.sub).await?;
+    let response = interactor.handle_list_fridges(&user.user_id).await?;
     Ok(HttpResponse::Ok().json(list_schema::ListFridgesResponse::from(response)))
 }

--- a/src/interface/rest-controller/src/handler/item.rs
+++ b/src/interface/rest-controller/src/handler/item.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::extractor::AuthenticatedUser;
 use crate::schema::item::create::{self as create_schema};
 use crate::schema::item::update::{self as update_schema};
 use actix_web::{HttpResponse, web};
@@ -13,6 +14,7 @@ use uuid::Uuid;
 
 pub async fn create_item<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<(String, String)>,
     req: web::Json<create_schema::CreateItemRequest>,
 ) -> Result<HttpResponse> {
@@ -34,7 +36,9 @@ pub async fn create_item<R: Repository + 'static>(
         unit,
         req.expires_at,
     );
-    let item = interactor.handle_create_item(use_case_request).await?;
+    let item = interactor
+        .handle_create_item(&user.user_id, use_case_request)
+        .await?;
 
     let response = create_schema::CreateItemResponse::from(item);
     Ok(HttpResponse::Created().json(response))
@@ -42,6 +46,7 @@ pub async fn create_item<R: Repository + 'static>(
 
 pub async fn update_item<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<(String, String, String)>,
     req: web::Json<update_schema::UpdateItemRequest>,
 ) -> Result<HttpResponse> {
@@ -57,7 +62,7 @@ pub async fn update_item<R: Repository + 'static>(
     let use_case_request =
         UpdateItemRequest::new(item_id, name, req.quantity, unit, req.expires_at);
     let item = interactor
-        .handle_update_item(&compartment_id_str, use_case_request)
+        .handle_update_item(&user.user_id, &compartment_id_str, use_case_request)
         .await?;
 
     let response = update_schema::UpdateItemResponse::from(item);
@@ -66,11 +71,12 @@ pub async fn update_item<R: Repository + 'static>(
 
 pub async fn delete_item<R: Repository + 'static>(
     interactor: web::Data<Arc<Interactor<R>>>,
+    user: AuthenticatedUser,
     path: web::Path<(String, String, String)>,
 ) -> Result<HttpResponse> {
     let (_fridge_id_str, compartment_id_str, item_id_str) = path.into_inner();
     interactor
-        .handle_delete_item(&compartment_id_str, &item_id_str)
+        .handle_delete_item(&user.user_id, &compartment_id_str, &item_id_str)
         .await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/src/interface/rest-controller/src/schema/fridge/create/request.rs
+++ b/src/interface/rest-controller/src/schema/fridge/create/request.rs
@@ -3,5 +3,4 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct CreateFridgeRequest {
     pub name: String,
-    pub owner_user_id: String,
 }

--- a/src/use-case/src/interactor/compartment/mod.rs
+++ b/src/use-case/src/interactor/compartment/mod.rs
@@ -8,15 +8,12 @@ use fridgers_backend_domain::compartment::Compartment;
 impl<R: Repository> crate::interactor::Interactor<R> {
     pub async fn handle_create_compartment(
         &self,
+        requesting_user_id: &str,
         request: CreateCompartmentRequest,
     ) -> Result<Compartment> {
-        // 冷蔵庫の存在確認
-        self.repository
-            .find_fridge_by_id(&request.fridge_id.value().to_string())
-            .await?
-            .ok_or_else(|| {
-                Error::NotFound(format!("Fridge not found: {}", request.fridge_id.value()))
-            })?;
+        // 冷蔵庫のオーナー確認（存在＋所有者一致）
+        self.verify_fridge_ownership(requesting_user_id, &request.fridge_id.value().to_string())
+            .await?;
 
         let compartment = Compartment::new(request.compartment_id, request.fridge_id, request.name);
         self.repository.save_compartment(&compartment).await?;
@@ -25,6 +22,7 @@ impl<R: Repository> crate::interactor::Interactor<R> {
 
     pub async fn handle_update_compartment(
         &self,
+        requesting_user_id: &str,
         request: UpdateCompartmentRequest,
     ) -> Result<Compartment> {
         // コンパートメントの存在確認と所属確認
@@ -46,6 +44,16 @@ impl<R: Repository> crate::interactor::Interactor<R> {
             )));
         }
 
+        // 冷蔵庫オーナー確認（パスの fridge_id でチェック）
+        self.verify_fridge_ownership(requesting_user_id, &request.fridge_id.value().to_string())
+            .await
+            .map_err(|_| {
+                Error::NotFound(format!(
+                    "Compartment not found: {}",
+                    request.compartment_id.value()
+                ))
+            })?;
+
         let updated = Compartment::new(request.compartment_id, request.fridge_id, request.name);
         self.repository.update_compartment(&updated).await?;
         Ok(updated)
@@ -53,6 +61,7 @@ impl<R: Repository> crate::interactor::Interactor<R> {
 
     pub async fn handle_delete_compartment(
         &self,
+        requesting_user_id: &str,
         fridge_id: &str,
         compartment_id: &str,
     ) -> Result<()> {
@@ -68,6 +77,11 @@ impl<R: Repository> crate::interactor::Interactor<R> {
                 compartment_id
             )));
         }
+
+        // 冷蔵庫オーナー確認
+        self.verify_fridge_ownership(requesting_user_id, fridge_id)
+            .await
+            .map_err(|_| Error::NotFound(format!("Compartment not found: {}", compartment_id)))?;
 
         self.repository.delete_compartment(compartment_id).await
     }

--- a/src/use-case/src/interactor/fridge/delete.rs
+++ b/src/use-case/src/interactor/fridge/delete.rs
@@ -3,8 +3,10 @@ use crate::interactor::Interactor;
 use crate::repository::Repository;
 
 impl<R: Repository> Interactor<R> {
-    /// 冷蔵庫を削除する
-    pub async fn handle_delete_fridge(&self, id: &str) -> Result<()> {
+    /// 冷蔵庫を削除する。
+    /// 認証済ユーザーが冷蔵庫のオーナーでない場合は NotFound を返す。
+    pub async fn handle_delete_fridge(&self, requesting_user_id: &str, id: &str) -> Result<()> {
+        self.verify_fridge_ownership(requesting_user_id, id).await?;
         self.repository.delete_fridge(id).await
     }
 }

--- a/src/use-case/src/interactor/fridge/find.rs
+++ b/src/use-case/src/interactor/fridge/find.rs
@@ -1,16 +1,17 @@
+use crate::Result;
 use crate::dto::fridge::get::{CompartmentWithItems, FridgeWithCompartments};
 use crate::interactor::Interactor;
 use crate::repository::Repository;
-use crate::{Error, Result};
 
 impl<R: Repository> Interactor<R> {
-    /// 冷蔵庫IDで冷蔵庫をコンパートメント・アイテムとともに取得する
-    pub async fn handle_get_fridge(&self, id: &str) -> Result<FridgeWithCompartments> {
-        let fridge = self
-            .repository
-            .find_fridge_by_id(id)
-            .await?
-            .ok_or_else(|| Error::NotFound(format!("Fridge not found: {}", id)))?;
+    /// 冷蔵庫IDで冷蔵庫をコンパートメント・アイテムとともに取得する。
+    /// 認証済ユーザーが冷蔵庫のオーナーでない場合は NotFound を返す。
+    pub async fn handle_get_fridge(
+        &self,
+        requesting_user_id: &str,
+        id: &str,
+    ) -> Result<FridgeWithCompartments> {
+        let fridge = self.verify_fridge_ownership(requesting_user_id, id).await?;
 
         let compartments = self.repository.find_compartments_by_fridge_id(id).await?;
 

--- a/src/use-case/src/interactor/item/mod.rs
+++ b/src/use-case/src/interactor/item/mod.rs
@@ -7,17 +7,17 @@ use chrono::Utc;
 use fridgers_backend_domain::item::Item;
 
 impl<R: Repository> crate::interactor::Interactor<R> {
-    pub async fn handle_create_item(&self, request: CreateItemRequest) -> Result<Item> {
-        // コンパートメントの存在確認
-        self.repository
-            .find_compartment_by_id(&request.compartment_id.value().to_string())
-            .await?
-            .ok_or_else(|| {
-                Error::NotFound(format!(
-                    "Compartment not found: {}",
-                    request.compartment_id.value()
-                ))
-            })?;
+    pub async fn handle_create_item(
+        &self,
+        requesting_user_id: &str,
+        request: CreateItemRequest,
+    ) -> Result<Item> {
+        // コンパートメントの存在確認＋親冷蔵庫のオーナー確認
+        self.verify_compartment_ownership(
+            requesting_user_id,
+            &request.compartment_id.value().to_string(),
+        )
+        .await?;
 
         let now = Utc::now();
         let item = Item::new(
@@ -36,6 +36,7 @@ impl<R: Repository> crate::interactor::Interactor<R> {
 
     pub async fn handle_update_item(
         &self,
+        requesting_user_id: &str,
         compartment_id: &str,
         request: UpdateItemRequest,
     ) -> Result<Item> {
@@ -54,6 +55,11 @@ impl<R: Repository> crate::interactor::Interactor<R> {
             )));
         }
 
+        // 親冷蔵庫のオーナー確認（パスの compartment_id 経由）
+        self.verify_compartment_ownership(requesting_user_id, compartment_id)
+            .await
+            .map_err(|_| Error::NotFound(format!("Item not found: {}", request.item_id.value())))?;
+
         let updated = Item::new(
             request.item_id,
             existing.compartment_id,
@@ -68,7 +74,12 @@ impl<R: Repository> crate::interactor::Interactor<R> {
         Ok(updated)
     }
 
-    pub async fn handle_delete_item(&self, compartment_id: &str, item_id: &str) -> Result<()> {
+    pub async fn handle_delete_item(
+        &self,
+        requesting_user_id: &str,
+        compartment_id: &str,
+        item_id: &str,
+    ) -> Result<()> {
         let existing = self
             .repository
             .find_item_by_id(item_id)
@@ -78,6 +89,11 @@ impl<R: Repository> crate::interactor::Interactor<R> {
         if existing.compartment_id.value().to_string() != compartment_id {
             return Err(Error::NotFound(format!("Item not found: {}", item_id)));
         }
+
+        // 親冷蔵庫のオーナー確認
+        self.verify_compartment_ownership(requesting_user_id, compartment_id)
+            .await
+            .map_err(|_| Error::NotFound(format!("Item not found: {}", item_id)))?;
 
         self.repository.delete_item(item_id).await
     }

--- a/src/use-case/src/interactor/mod.rs
+++ b/src/use-case/src/interactor/mod.rs
@@ -6,6 +6,9 @@ pub mod user;
 
 use crate::auth::JwtConfig;
 use crate::repository::Repository;
+use crate::{Error, Result};
+use fridgers_backend_domain::compartment::Compartment;
+use fridgers_backend_domain::fridge::Fridge;
 
 pub struct Interactor<R: Repository> {
     pub repository: R,
@@ -18,5 +21,47 @@ impl<R: Repository> Interactor<R> {
             repository,
             jwt_config,
         }
+    }
+
+    /// 指定した冷蔵庫のオーナーが requesting_user_id と一致することを確認する。
+    /// 一致しない場合・冷蔵庫が存在しない場合はいずれも NotFound（リソース存在の漏洩防止）。
+    pub(crate) async fn verify_fridge_ownership(
+        &self,
+        requesting_user_id: &str,
+        fridge_id: &str,
+    ) -> Result<Fridge> {
+        let fridge = self
+            .repository
+            .find_fridge_by_id(fridge_id)
+            .await?
+            .ok_or_else(|| Error::NotFound(format!("Fridge not found: {}", fridge_id)))?;
+
+        if fridge.owner_user_id.value().to_string() != requesting_user_id {
+            return Err(Error::NotFound(format!("Fridge not found: {}", fridge_id)));
+        }
+
+        Ok(fridge)
+    }
+
+    /// 指定したコンパートメントの親冷蔵庫のオーナーが requesting_user_id と一致することを確認する。
+    pub(crate) async fn verify_compartment_ownership(
+        &self,
+        requesting_user_id: &str,
+        compartment_id: &str,
+    ) -> Result<Compartment> {
+        let compartment = self
+            .repository
+            .find_compartment_by_id(compartment_id)
+            .await?
+            .ok_or_else(|| Error::NotFound(format!("Compartment not found: {}", compartment_id)))?;
+
+        self.verify_fridge_ownership(
+            requesting_user_id,
+            &compartment.fridge_id.value().to_string(),
+        )
+        .await
+        .map_err(|_| Error::NotFound(format!("Compartment not found: {}", compartment_id)))?;
+
+        Ok(compartment)
     }
 }


### PR DESCRIPTION
## Summary
- Actix の \`FromRequest\` を実装した \`AuthenticatedUser\` 抽出器を新設。ハンドラの引数として宣言するだけで認証済ユーザーIDを取得できる
- Interactor に \`verify_fridge_ownership\` / \`verify_compartment_ownership\` ヘルパーを追加し、全アクション系メソッドが \`requesting_user_id\` を受け取りオーナーシップを確認する
- 他人のリソースへのアクセスは存在を漏らさず \`404 Not Found\` を返す（\`403 Forbidden\` ではなく）

Closes #15

## 破壊的変更

| エンドポイント | 変更内容 |
|---|---|
| \`POST /v1/fridges\` | リクエストボディから \`owner_user_id\` を削除。JWT の \`sub\` をオーナーとして使用 |
| \`GET /v1/fridges/{id}\` | Bearer 必須。他人の冷蔵庫は 404 |
| \`DELETE /v1/fridges/{id}\` | Bearer 必須。他人の冷蔵庫は 404（削除されない） |
| \`POST/PUT/DELETE /v1/fridges/{id}/compartments\` 系 | Bearer 必須。冷蔵庫オーナーのみ操作可 |
| \`POST/PUT/DELETE /v1/fridges/{id}/compartments/{cid}/items\` 系 | Bearer 必須。冷蔵庫オーナーのみ操作可 |

認証不要のまま残るのは \`POST /v1/users\` と \`POST /v1/auth/login\` のみ。

## Test plan
- [x] \`cargo build\` / \`cargo fmt\`
- [x] \`cargo test --test integration_test -- --test-threads=1\` (20/20 pass)
  - うち新規認可テスト 7 件:
    - \`test_create_fridge_without_auth_returns_401\`
    - \`test_create_fridge_uses_jwt_user_as_owner\` (body から owner_user_id 削除を検証)
    - \`test_get_fridge_of_other_user_returns_404\`
    - \`test_get_fridge_owner_succeeds\`
    - \`test_delete_fridge_of_other_user_returns_404_and_does_not_delete\` (削除も実際に効かないことを GET で確認)
    - \`test_create_compartment_in_other_user_fridge_returns_404\`
    - \`test_create_item_in_other_user_compartment_returns_404\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)